### PR TITLE
Conditionally Render Checkout Payment Buttons

### DIFF
--- a/src/components/PaymentButton.tsx
+++ b/src/components/PaymentButton.tsx
@@ -1,0 +1,39 @@
+import { StyleSheet } from 'react-native';
+import { Button } from '@ui-kitten/components';
+import React from 'react';
+
+interface PaymentButtonProps {
+    paymentMethod: string;
+    onPress: () => void;
+    isSelected: boolean;
+}
+
+const PaymentButton = ({ paymentMethod, onPress, isSelected }: PaymentButtonProps) => {
+    return (
+        <Button
+            style={[styles.button, isSelected && styles.selectedButton]}
+            appearance='outline'
+            status='info'
+            size='giant'
+            onPress={onPress}
+        >
+            {paymentMethod}
+        </Button>
+    );
+}
+
+export default PaymentButton;
+
+const styles = StyleSheet.create({
+    button: {
+        width: "100%",
+        marginTop: 15,
+        margin: 2,
+    },
+    selectedButton: {
+        width: "100%",
+        marginTop: 15,
+        margin: 2,
+        backgroundColor: 'lightblue',
+    }
+});

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -65,25 +65,28 @@ export const useAuth = () => {
     console.log("BEGIN SignUp");
     const fbResponse = initResponse();
     await createUserWithEmailAndPassword(auth, userEmail, userPassword)
-      .then((userCredential) => {
+      .then(async (userCredential) => {
         fbResponse.result = userCredential;
 
         // create user in firestore
         const userRef = doc(db, "users", userCredential.user.uid);
-        const userDoc = getDoc(userRef);
-        setDoc(userRef, {
+        await setDoc(userRef, {
           name: userFullName,
           email: userEmail,
           created: serverTimestamp(),
           hostReceipts: [],
           memberReceipts: [],
           hasAccount: true,
-          phoneNumber: ""
+          phoneNumber: "",
+          paymentMethods: {
+            Venmo: null,
+            CashApp: null,
+            PayPal: null,
+          },
         })
-
         // Update profile
         if (auth.currentUser) {
-          updateProfile(auth.currentUser, {
+          await updateProfile(auth.currentUser, {
             displayName: userFullName,
           });
         }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -179,9 +179,11 @@ export const useAuth = () => {
     user?.providerData.forEach((profile) => {
       const fbProfile: IFirebaseUser = {
         ...profile, firebaseUID: user.uid,
-        cashAppName: null,
-        venmoName: null,
-        paypalEmail: null,
+        paymentMethods: {
+          Venmo: null,
+          CashApp: null,
+          PayPal: null,
+        },
       };
       console.log("getProfile SUCCESS");
       return fbProfile;

--- a/src/hooks/useFirestore.ts
+++ b/src/hooks/useFirestore.ts
@@ -267,9 +267,11 @@ export const useFirestore = () => {
           firebaseUID: userDoc.id,
           providerId: "",
           uid: userData.uid,
-          cashAppName: userData.cashAppName || "",
-          venmoName: userData.venmoName || "",
-          paypalEmail: userData.paypalEmail || "",
+          paymentMethods: {
+            Venmo: userData.paymentMethods?.Venmo || null,
+            CashApp: userData.paymentMethods?.CashApp || null,
+            PayPal: userData.paymentMethods?.PayPal || null,
+          },
         };
       } else {
         console.log("Firestore User Document does not exist");
@@ -281,7 +283,7 @@ export const useFirestore = () => {
     }
   };
 
-  //TODO: Add function to reauthenticate, similar to the password shit
+  // Reauthenticate user before updating password if signed in for a long time.
   const reauthenticateUser = async (password: string) => {
     const user = auth.currentUser
     try {
@@ -363,8 +365,15 @@ export const useFirestore = () => {
       const user = auth.currentUser;
       if (user) {
         const userRef = doc(db, "users", user.uid);
+        const userDoc = await getDoc(userRef);
+
+        const paymentMethods = {
+          ...userDoc.data()?.paymentMethods,
+          Venmo: venmoName,
+        };
+
         await updateDoc(userRef, {
-          venmoName: venmoName,
+          paymentMethods: paymentMethods,
         });
         console.log("Venmo name updated successfully");
       }
@@ -380,8 +389,15 @@ export const useFirestore = () => {
       const user = auth.currentUser;
       if (user) {
         const userRef = doc(db, "users", user.uid);
+        const userDoc = await getDoc(userRef);
+        
+        const paymentMethods = {
+          ...userDoc.data()?.paymentMethods,
+          CashApp: cashAppName,
+        };
+
         await updateDoc(userRef, {
-          cashAppName: cashAppName,
+          paymentMethods: paymentMethods,
         });
         console.log("Cash App name updated successfully");
       }
@@ -396,8 +412,15 @@ export const useFirestore = () => {
       const user = auth.currentUser;
       if (user) {
         const userRef = doc(db, "users", user.uid);
+        const userDoc = await getDoc(userRef);
+        
+        const paymentMethods = {
+          ...userDoc.data()?.paymentMethods,
+          PayPal: paypalEmail,
+        };
+
         await updateDoc(userRef, {
-          paypalEmail: paypalEmail,
+          paymentMethods: paymentMethods,
         });
         console.log("Paypal email updated successfully");
       }

--- a/src/interfaces/IAuthentication.ts
+++ b/src/interfaces/IAuthentication.ts
@@ -11,9 +11,11 @@ export interface IFirebaseResponse {
 // extend the firebase user object
 export interface IFirebaseUser extends UserInfo {
   firebaseUID: string | null;
-  cashAppName: string | null;
-  venmoName: string | null;
-  paypalEmail: string | null;  //should be the email address associated with the account
+  paymentMethods: {
+    Venmo: string | null;
+    CashApp: string | null;
+    PayPal: string | null;
+  };
 }
 
 // Omit properties we don't use

--- a/src/screens/shared/EditPaymentSettingsScreen.tsx
+++ b/src/screens/shared/EditPaymentSettingsScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View, ScrollView, Alert, StyleSheet } from "react-native";
-import { Text,TextInput, Button } from "react-native-paper";
+import { Text, TextInput, Button } from "react-native-paper";
 import { useFirestore } from "../../hooks/useFirestore";
+import { useValidation } from "../../hooks/useValidation";
 
 const EditPaymentSettingsScreen = ({
   route,
@@ -17,49 +18,63 @@ const EditPaymentSettingsScreen = ({
   const [cashAppNameError, setCashAppNameError] = useState("");
   const [paypalEmail, setPaypalEmail] = useState("");
   const [paypalEmailError, setPaypalEmailError] = useState("");
-  const { updateVenmoName, updateCashAppName, updatePaypalEmail } = useFirestore();
+  const { updateVenmoName, updateCashAppName, updatePaypalEmail } =
+    useFirestore();
+  const { validateEmail } = useValidation();
+
+  useEffect(() => {
+    setVenmoName(profile.paymentMethods.Venmo || "");
+    setCashAppName(profile.paymentMethods.CashApp || "");
+    setPaypalEmail(profile.paymentMethods.PayPal || "");
+  }, []);
 
   const handleSave = async () => {
     if (
-      venmoName !== profile?.venmoName &&
+      venmoName !== profile?.paymentMethods?.Venmo &&
       venmoName !== "" &&
       venmoName !== null
     ) {
       try {
         await updateVenmoName(venmoName);
         setVenmoNameError("");
-      } catch (error) {
+      } catch (error: any) {
         console.log("Error updating venmo name:", error);
-        setVenmoNameError("Error updating Venmo Username.. Please try again");
+        setVenmoNameError("Error updating Venmo Username.. " + error.message);
         return;
       }
-      
-    } 
+    }
     if (
-      cashAppName !== profile?.cashAppName &&
+      cashAppName !== profile?.paymentMethods?.CashApp &&
       cashAppName !== "" &&
       cashAppName !== null
     ) {
       try {
         await updateCashAppName(cashAppName);
         setCashAppNameError("");
-      } catch (error) {
+      } catch (error: any) {
         console.log("Error updating cash app name:", error);
-        setCashAppNameError("Error updating Cash App Username.. Please try again");
+        setCashAppNameError(
+          "Error updating Cash App Username.. " + error.message
+        );
         return;
       }
     }
     if (
-      paypalEmail !== profile?.paypalEmail &&
+      paypalEmail !== profile?.paymentMethods?.PayPal &&
       paypalEmail !== "" &&
       paypalEmail !== null
     ) {
       try {
+        // Validate the email using useValidation
+        if (!validateEmail(paypalEmail)) {
+          throw new Error("Invalid email address");
+        }
+
         await updatePaypalEmail(paypalEmail);
         setPaypalEmailError("");
-      } catch (error) {
+      } catch (error: any) {
         console.log("Error updating paypal email:", error);
-        setPaypalEmailError("Error updating PayPal email.. Please try again");
+        setPaypalEmailError("Error updating PayPal email.. " + error.message);
         return;
       }
     }
@@ -89,7 +104,7 @@ const EditPaymentSettingsScreen = ({
                 mode="outlined"
                 value={venmoName}
                 onChangeText={setVenmoName}
-                placeholder={profile?.venmoName || "Enter Venmo Username"}
+                placeholder={"Enter Venmo Username"}
               />
             </View>
           </View>
@@ -106,7 +121,7 @@ const EditPaymentSettingsScreen = ({
                 mode="outlined"
                 value={cashAppName}
                 onChangeText={setCashAppName}
-                placeholder={profile?.cashAppName || "Enter Cash App Username"}
+                placeholder={"Enter Cash App Username"}
               />
             </View>
           </View>
@@ -123,7 +138,7 @@ const EditPaymentSettingsScreen = ({
                 mode="outlined"
                 value={paypalEmail}
                 onChangeText={setPaypalEmail}
-                placeholder={profile?.paypalEmail || "Enter PayPal Email Address"}
+                placeholder={"Enter PayPal Email Address"}
               />
             </View>
           </View>
@@ -147,62 +162,62 @@ const EditPaymentSettingsScreen = ({
 export default EditPaymentSettingsScreen;
 
 const styles = StyleSheet.create({
-    container: {
-      paddingVertical: 24,
-      paddingHorizontal: 0,
-      flexGrow: 1,
-      flexShrink: 1,
-      flexBasis: 0,
-    },
-    header: {
-      paddingLeft: 24,
-      paddingRight: 24,
-      marginBottom: 24,
-      borderColor: "#e3e3e3",
-    },
-    title: {
-      fontSize: 32,
-      fontWeight: "700",
-      color: "#1d1d1d",
-      marginBottom: 6,
-    },
-    row: {
-      alignItems: "center",
-      justifyContent: "flex-end",
-      height: 50,
-    },
-    rowWrapper: {
-      paddingBottom: 6,
-      paddingTop: 6,
-    },
-    rowLabel: {
-      fontSize: 17,
-      fontWeight: "500",
-      paddingBottom: 10,
-      paddingLeft: 24,
-      paddingRight: 24,
-      color: "#000",
-    },
-    rowValue: {
-      fontSize: 17,
-      fontWeight: "500",
-      borderColor: "#cccccc",
-      flex: 1,
-    },
-    errorText: {
-      fontSize: 12,
-      fontWeight: "500",
-      color: "red",
-      marginLeft: 24,
-      marginRight: 24,
-    },
-  
-    rowValueContainer: {
-      flexGrow: 1,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "flex-end",
-      paddingRight: 24,
-      paddingLeft: 24,
-    },
-  });
+  container: {
+    paddingVertical: 24,
+    paddingHorizontal: 0,
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+  },
+  header: {
+    paddingLeft: 24,
+    paddingRight: 24,
+    marginBottom: 24,
+    borderColor: "#e3e3e3",
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: "700",
+    color: "#1d1d1d",
+    marginBottom: 6,
+  },
+  row: {
+    alignItems: "center",
+    justifyContent: "flex-end",
+    height: 50,
+  },
+  rowWrapper: {
+    paddingBottom: 6,
+    paddingTop: 6,
+  },
+  rowLabel: {
+    fontSize: 17,
+    fontWeight: "500",
+    paddingBottom: 10,
+    paddingLeft: 24,
+    paddingRight: 24,
+    color: "#000",
+  },
+  rowValue: {
+    fontSize: 17,
+    fontWeight: "500",
+    borderColor: "#cccccc",
+    flex: 1,
+  },
+  errorText: {
+    fontSize: 12,
+    fontWeight: "500",
+    color: "red",
+    marginLeft: 24,
+    marginRight: 24,
+  },
+
+  rowValueContainer: {
+    flexGrow: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingRight: 24,
+    paddingLeft: 24,
+  },
+});

--- a/src/screens/shared/SelectItemsScreen.tsx
+++ b/src/screens/shared/SelectItemsScreen.tsx
@@ -88,7 +88,7 @@ const MyReceiptsScreen = ({ route, navigation }: { route: any, navigation: any }
     }
 
     const handleGuestCheckout = async () => {
-        navigation.navigate('GuestCheckout', { receiptId: receiptId, total: individualTotal, host: host });
+        navigation.navigate('GuestCheckout', { receiptId: receiptId, total: individualTotal, host: host });        
     }
 
     const handleCheckout = async () => {
@@ -152,6 +152,7 @@ const MyReceiptsScreen = ({ route, navigation }: { route: any, navigation: any }
                         <Button
                             style={styles.button}
                             onPress={handleCheckout}
+                            disabled={selectedItems.length === 0 && (receipt && receipt.host !== auth.currentUser?.uid)}
                         >
                             Checkout
                         </Button>

--- a/src/screens/shared/SelectItemsScreen.tsx
+++ b/src/screens/shared/SelectItemsScreen.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from "../../store/hook";
 import { selectAuthState } from "../../store/authSlice";
 import {auth} from "../../services/firebase";
 import { set } from 'react-hook-form';
+import { IFirebaseUser } from '../../interfaces/IAuthentication';
 
 const PlusIcon = (props): IconElement => (
     <Icon
@@ -23,17 +24,22 @@ const PlusIcon = (props): IconElement => (
 const MyReceiptsScreen = ({ route, navigation }: { route: any, navigation: any }): React.ReactElement => {
     const { receiptId } = route.params;
     const authState = useAppSelector(selectAuthState);
-    const { getReceiptById, updateItemsPaidStatus } = useFirestore();
+    const { getReceiptById, updateItemsPaidStatus, getFirestoreUser } = useFirestore();
     const [items, setItems] = useState<IReceiptItem[] | undefined>([]);
     const [receipt, setReceipt] = useState<IReceipt | undefined>(undefined);
     const [selectedItems, setSelectedItems] = useState<IReceiptItem[]>([]);
     const [individualTotal, setIndividualTotal] = useState<number>(0);
+    const [host, setHost] = useState<IFirebaseUser | null>(null);
 
     useEffect(() => {
         const fetchReceipts = async () => {
             try {
                 const receipt = await getReceiptById(receiptId);
                 setReceipt(receipt);
+                if (receipt && receipt?.host) {
+                    const host = await getFirestoreUser(receipt.host.toString())
+                    setHost(host);
+                }
             } catch (error) {
                 console.error('Error setting receipt items:', error);
             }
@@ -82,7 +88,7 @@ const MyReceiptsScreen = ({ route, navigation }: { route: any, navigation: any }
     }
 
     const handleGuestCheckout = async () => {
-        navigation.navigate('GuestCheckout', { receiptId: receiptId, total: individualTotal });
+        navigation.navigate('GuestCheckout', { receiptId: receiptId, total: individualTotal, host: host });
     }
 
     const handleCheckout = async () => {


### PR DESCRIPTION
- Conditionally render the payment options shown based on what the host of the receipt supports. 

- Create checkout button component.

- Update how user payment methods are stored in Firebase.
       - `'paymentMethods { Venmo: "", CashApp: "", PayPal: "" }'`
       
- Get host state in ReceiptItems page to pass to checkout screen.

- Fix bug related to signup (await signing in after new signup to ensure all firebase data is loaded).

- Only allow Guests in a receipt group to proceed to checkout once they have selected an item to pay for.